### PR TITLE
feat: return value should be silent

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,14 @@
 var plugin = require('shelljs/plugin');
-var clear = require('clear');
+var clearModule = require('clear');
+
+function clear() {
+  clearModule();
+  return {
+    inspect: function () {
+      return '';
+    },
+  };
+}
 
 plugin.register('clear', clear, {
   allowGlobbing: false,

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ var pluginClear = require('..');
 
 var shell = require('shelljs');
 
-var should = require('should');
+require('should');
 
 // override console.error() to cover up common.error() calls
 console.error = function () { };
@@ -34,9 +34,9 @@ describe('plugin-clear', function () {
     pluginClear.clear.should.be.type('function');
   });
 
-  it('returns undefined', function () {
+  it('has a silent return value', function () {
     var ret = shell.clear();
-    should(ret === undefined);
+    ret.inspect().should.equal('');
   });
 
   it('does not get added as a method on ShellStrings', function () {


### PR DESCRIPTION
The return value from the `shell.clear()` command is now silent. It has a
`.inspect()` which returns the empty string. This has a nicer visual appearance
in terminals.

Fixes #3