### PR TITLE
chore(travis): simpler config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,14 @@
-language: c++
+language: node_js
 sudo: false
-env:
-  - NODE_VERSION="8"
-  - NODE_VERSION="10"
-  - NODE_VERSION="12"
-  - NODE_VERSION="13"
-
-# keep this blank to make sure there are no before_install steps
-before_install:
-
-install:
-  - rm -rf ~/.nvm
-  - git clone https://github.com/creationix/nvm.git ~/.nvm
-  - source ~/.nvm/nvm.sh
-  - nvm install $NODE_VERSION
-  - node --version
-  - npm install
+node_js:
+  - 8
+  - 10
+  - 12
+  - 13
 os:
   - linux
   - osx
 script:
   - npm test
+notifications:
+  email: false


### PR DESCRIPTION
This uses `language: node_js` for travis, since it's long since had OS X
node support. This also suppresses email notifications, since these
aren't terribly helpful.