### PR TITLE
chore: update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+package-lock.json
 
 *~
 *.swp

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-# We can't use lockfiles because npm@5 and npm@6 disagree about the syntax (and
-# will modify the lockfile when we run `npm install`).
-package-lock=false

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
     "mocha": "^6.1.4",
-    "shelljs": "^0.8.1",
-    "shelljs-changelog": "^0.2.2",
-    "shelljs-release": "^0.2.0",
+    "shelljs": "^0.8.5",
+    "shelljs-changelog": "^0.2.6",
+    "shelljs-release": "^0.5.2",
     "should": "^13.2.3"
   },
   "peerDependencies": {
-    "shelljs": "^0.8.0"
+    "shelljs": "^0.8.5"
   },
   "dependencies": {
     "clear": "0.0.1"


### PR DESCRIPTION
This updates dependencies without changing min node version. This allows
package-lock.json in local checkouts.