### PR TITLE
chore: restore node v4 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 4
+          - 6
           - 8
           - 10
           - 12

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "index.js"
   ],
   "devDependencies": {
-    "eslint": "^5.16.0",
+    "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
-    "mocha": "^6.1.4",
+    "mocha": "^5.2.0",
     "shelljs": "^0.8.5",
     "shelljs-changelog": "^0.2.6",
     "shelljs-release": "^0.5.2",
@@ -43,6 +43,6 @@
     "clear": "0.0.1"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=4"
   }
 }


### PR DESCRIPTION
No change to logic. This downgrades some devDependencies to restore node
v4 support.