### PR TITLE
fix: use new attribute for repl inspection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,17 @@
 var plugin = require('shelljs/plugin');
+var util = require('util');
 var clearModule = require('clear');
+
+// Newer versions of node use a symbol called util.inspect.custom.
+var inspectAttribute = util.inspect.custom || 'inspect';
 
 function clear() {
   clearModule();
-  return {
-    inspect: function () {
-      return '';
-    },
+  var ret = {};
+  ret[inspectAttribute] = function () {
+    return '';
   };
+  return ret;
 }
 
 plugin.register('clear', clear, {

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ var pluginClear = require('..');
 // If we were using additional plugins, we could load them here
 
 var shell = require('shelljs');
+var util = require('util');
 
 require('should');
 
@@ -36,7 +37,7 @@ describe('plugin-clear', function () {
 
   it('has a silent return value', function () {
     var ret = shell.clear();
-    ret.inspect().should.equal('');
+    util.inspect(ret).should.equal('');
   });
 
   it('does not get added as a method on ShellStrings', function () {


### PR DESCRIPTION
This updates the custom inspect implementation to use the preferred
attribute for compatibility with newer node versions.

See https://github.com/nfischer/shelljs-plugin-inspect/issues/9 for more
details.