### PR TITLE
chore: skip lint on node v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm run test
+      - run: npm run test-without-lint
+      - name: run lint (node >= 6)
+        run: npm run lint
+        if: matrix.node-version >= 6

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "posttest": "npm run lint",
     "test": "mocha",
+    "test-without-lint": "mocha",
     "lint": "eslint .",
     "changelog": "shelljs-changelog",
     "release:major": "shelljs-release major",


### PR DESCRIPTION
The lint command appears to be broken on node v4. It should be fine to skip this on v4 though since we can run lint on >= v6.

Fixes #15